### PR TITLE
Improve Code Rendering

### DIFF
--- a/scss/content/_code.scss
+++ b/scss/content/_code.scss
@@ -48,7 +48,8 @@
   #{$parent-selector} code,
   #{$parent-selector} kbd {
     display: inline-block;
-    padding: 0.375rem;
+    padding: 0.125rem 0.375rem;
+    vertical-align: middle;
   }
 
   #{$parent-selector} pre {

--- a/scss/content/_code.scss
+++ b/scss/content/_code.scss
@@ -55,13 +55,13 @@
   #{$parent-selector} pre {
     display: block;
     margin-bottom: var(#{$css-var-prefix}spacing);
-    overflow-x: auto;
 
     > code {
       display: block;
       padding: var(#{$css-var-prefix}spacing);
       background: none;
       line-height: var(#{$css-var-prefix}line-height);
+      overflow-x: auto;
     }
   }
 


### PR DESCRIPTION
This PR improves the style for block and inline `<code> ` tags.

#  Fix Overflow

Commit: https://github.com/Yohn/PicoCSS/commit/37dac63930f27b8dd2894b48cb94e51521525122

Move the `overflow-x: auto;` property from `pre` to `code` to fix scrolling and padding.

| Before | After |
|-|-|
| ![pre-code-before](https://github.com/user-attachments/assets/fbb9dfb7-b222-4ade-8356-c66b23954203) | ![pre-code-after](https://github.com/user-attachments/assets/43819394-2bcc-40a7-bee2-da5198ec55f7) |

# Improve Inline Spacing

Commit: https://github.com/Yohn/PicoCSS/commit/3946e8fd98b89396c982cdb2d7d0227c37abab31

The inline `<code>` tags touch each other when stacked in multiple lines, so I adjusted the vertical padding to `0.125rem`. I also added `vertical-align: middle;` to improve the text alignment.

| Before | After |
|-|-|
| ![inline-code-before](https://github.com/user-attachments/assets/f24da1a1-ed72-4119-89b1-0fb8c9d01fe9) | ![inline-code-after](https://github.com/user-attachments/assets/f7a64b94-1c1a-4aab-a8b9-6b12550be41f) |

