### PR TITLE
FileValidator's bubbling 

### DIFF
--- a/docs/js/FileValidator.js
+++ b/docs/js/FileValidator.js
@@ -94,7 +94,10 @@ class FileValidator {
 		const removeButton = document.createElement("button");
 		removeButton.textContent = " ";
 		removeButton.className = "btn-file-rm";
-		removeButton.addEventListener("click", () => this.removeFile(file, listItem));
+		removeButton.addEventListener("click", (event) => {
+			event.stopPropagation(); // Prevent event from bubbling up to modal
+			this.removeFile(file, listItem);
+		});
 
 		listItem.append(removeButton);
 


### PR DESCRIPTION
Prevent the FileValidator's remove button from bubbling up and closing modals when its within a modal.